### PR TITLE
Resolves sign_in exception

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,12 @@ class User < ApplicationRecord
   # :token_authenticatable, :encryptable, :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable, :confirmable, :invitable, :timeoutable
-  audited except: [:encrypted_password, :confirmation_token, :invitation_token, :reset_password_token]
+  audited except: [:encrypted_password,
+                   :confirmation_token,
+                   :invitation_token,
+                   :reset_password_token,
+                   :remember_token,
+                   :remember_created_at]
 
   has_many :user_group_associations, dependent: :destroy
   has_many :groups, through: :user_group_associations


### PR DESCRIPTION
It resolves a bug related to the user being signed in and remembered. After session expiration, when the user wants to use the app, the system logs the user out and tries to log the change (audited gem). Since the gem is configured to log remember_token, and remember_created_at fields it tries to fetch current user and the whole process starts again, creating infinite loop and producing stack level too deep exception. The fix is to disable logging changes for remember_token and remember_created_at for audited gem.