### PR TITLE
Fixes editing entry item for one_percent category

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,6 +13,7 @@ class Item < ApplicationRecord
 
   before_validation :remove_nil_amount_grants
   before_validation :remove_zero_amount_grants
+  before_validation :set_same_values_for_one_percent_category
 
   validate :cannot_have_amount_one_percent_greater_than_amount
   validate :cannot_have_amount_one_percent_if_amount_is_nil
@@ -23,8 +24,6 @@ class Item < ApplicationRecord
 
   validate :grants_and_one_percent_amount_should_have_same_sign_as_self_amount
 
-  before_save :set_same_values_for_one_percent_category
-
   def amount=(val)
     write_attribute :amount, val.to_s.gsub(/[,\s+]/, ',' => '.', '\s+' => '')
   end
@@ -34,7 +33,7 @@ class Item < ApplicationRecord
   end
 
   def set_same_values_for_one_percent_category
-    if self.category.is_one_percent then
+    if self.category.is_one_percent
       self.amount_one_percent = self.amount
     end
   end

--- a/test/unit/item_test.rb
+++ b/test/unit/item_test.rb
@@ -73,11 +73,10 @@ class ItemTest < ActiveSupport::TestCase
 
     #when
     item.amount_one_percent = 4
+    item.save!
 
     #then
-    assert_raise(ActiveRecord::RecordInvalid) {
-      item.save!
-    }
+    assert_equal(item.amount_one_percent, item.amount)
   end
 
   test 'should not update amount one percent if category type is not one percent' do


### PR DESCRIPTION
Enables entering lower amount by copying the amount value to the amount_one_percent before validation not before save.