### PR TITLE
Aktualizacja dla RoR 6.0 - zamiana `update_attributes` na `update`

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -86,7 +86,7 @@ class CategoriesController < ApplicationController
     authorize! :update, @category
 
     respond_to do |format|
-      if @category.update_attributes(category_params)
+      if @category.update(category_params)
         format.html { redirect_to categories_url, notice: 'Zmiany zapisane.' }
         format.json { head :ok }
       else

--- a/app/controllers/entries_controller.rb
+++ b/app/controllers/entries_controller.rb
@@ -91,7 +91,7 @@ class EntriesController < ApplicationController
 
     if params[:is_linked]
       if @entry.linked_entry
-        @entry.linked_entry.update_attributes(params[:linked_entry])
+        @entry.linked_entry.update(params[:linked_entry])
         linked_entry = @entry.linked_entry
       else
         linked_entry = Entry.new(params[:linked_entry])
@@ -101,7 +101,7 @@ class EntriesController < ApplicationController
     end
 
     respond_to do |format|
-      if @entry.update_attributes(entry_params)
+      if @entry.update(entry_params)
         format.html do
           if params[:entry][:referer]
             redirect_to params[:entry][:referer], notice: 'Zmiany zapisane'

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -43,7 +43,7 @@ class GroupsController < ApplicationController
     authorize! :update, @group
 
     respond_to do |format|
-      if @group.update_attributes(group_params)
+      if @group.update(group_params)
         format.html { redirect_to @group, notice: 'Group was successfully updated.' }
         format.json { head :ok }
       else

--- a/app/controllers/inventory_entries_controller.rb
+++ b/app/controllers/inventory_entries_controller.rb
@@ -192,7 +192,7 @@ class InventoryEntriesController < ApplicationController
     authorize! :update, @inventory_entry
 
     respond_to do |format|
-      if @inventory_entry.update_attributes(inventory_entries_params)
+      if @inventory_entry.update(inventory_entries_params)
         format.html { redirect_to @inventory_entry, notice: 'Zmiany zapisane.' }
         format.json { head :ok }
       else

--- a/app/controllers/inventory_sources_controller.rb
+++ b/app/controllers/inventory_sources_controller.rb
@@ -68,7 +68,7 @@ class InventorySourcesController < ApplicationController
     flash.keep
 
     respond_to do |format|
-      if @inventory_source.update_attributes(inventory_source_params)
+      if @inventory_source.update(inventory_source_params)
         format.html { redirect_to @inventory_source, notice: 'Inventory source was successfully updated.' }
         format.json { head :no_content }
       else

--- a/app/controllers/journal_types_controller.rb
+++ b/app/controllers/journal_types_controller.rb
@@ -61,7 +61,7 @@ class JournalTypesController < ApplicationController
     @journal_type = JournalType.find(params[:id])
 
     respond_to do |format|
-      if @journal_type.update_attributes(journal_type_params)
+      if @journal_type.update(journal_type_params)
         format.html { redirect_to @journal_type, notice: 'Zmiany zapisane.' }
         format.json { head :ok }
       else

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -54,7 +54,7 @@ class UnitsController < ApplicationController
     authorize! :update, @unit
 
     respond_to do |format|
-      if @unit.update_attributes(unit_params)
+      if @unit.update(unit_params)
         format.html { redirect_to @unit, notice: 'Zmiany zapisane.' }
         format.json { head :ok }
       else

--- a/app/controllers/user_group_associations_controller.rb
+++ b/app/controllers/user_group_associations_controller.rb
@@ -16,7 +16,7 @@ class UserGroupAssociationsController < ApplicationController
     authorize! :update, @user_group_association
 
     respond_to do |format|
-      if @user_group_association.update_attributes(uga_params)
+      if @user_group_association.update(uga_params)
         target = params[:from] == "group" ? @user_group_association.group : @user_group_association.user
 
         format.html { redirect_to target, notice: 'Zmiany zapisane.' }

--- a/app/controllers/user_unit_associations_controller.rb
+++ b/app/controllers/user_unit_associations_controller.rb
@@ -16,7 +16,7 @@ class UserUnitAssociationsController < ApplicationController
     authorize! :update, @user_unit_association
 
     respond_to do |format|
-      if @user_unit_association.update_attributes(uua_params)
+      if @user_unit_association.update(uua_params)
         target = params[:from] == "unit" ? @user_unit_association.unit : @user_unit_association.user
 
         format.html { redirect_to target, notice: 'Zmiany zapisane.' }

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -68,7 +68,7 @@ class UsersController < ApplicationController
     authorize! :set_superadmin, @user if params[:user][:set_superadmin]
 
     respond_to do |format|
-      if @user.update_attributes(user_params)
+      if @user.update(user_params)
         format.html { redirect_to @user, notice: 'Zmiany zapisane.' }
         format.json { head :ok }
       else

--- a/test/unit/entry_test.rb
+++ b/test/unit/entry_test.rb
@@ -43,7 +43,7 @@ class EntryTest < ActiveSupport::TestCase
     items << item1 << item2
 
     assert_raise(ActiveRecord::RecordInvalid){
-      entry.update_attributes!(:items => items)
+      entry.update!(:items => items)
     }
   end
 


### PR DESCRIPTION
Poprawka dla następującego ostrzeżenia:
> DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead)