### PR TITLE
Poprawki ostrzeżeń po aktualizacji Railsów do wersji 6.1

### DIFF
--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -103,8 +103,8 @@ class CategoriesController < ApplicationController
     authorize! :destroy, @category
     @category.destroy
 
-    if not @category.errors.values.blank?
-      flash.now[:category] = @category.errors.values.join("<br/>")
+    if not @category.errors.messages.blank?
+      flash.now[:category] = @category.errors.messages.values.join("<br/>")
     end
     flash.keep
 

--- a/app/controllers/inventory_sources_controller.rb
+++ b/app/controllers/inventory_sources_controller.rb
@@ -64,7 +64,7 @@ class InventorySourcesController < ApplicationController
     @inventory_source = InventorySource.find(params[:id])
     authorize! :update, @inventory_source
 
-    flash.now[:alert] = @inventory_source.errors.values.join("<br/>")
+    flash.now[:alert] = @inventory_source.errors.messages.values.join("<br/>")
     flash.keep
 
     respond_to do |format|
@@ -85,7 +85,7 @@ class InventorySourcesController < ApplicationController
     authorize! :destroy, @inventory_source
     @inventory_source.destroy
 
-    flash.now[:alert] = @inventory_source.errors.values.join("<br/>")
+    flash.now[:alert] = @inventory_source.errors.messages.values.join("<br/>")
     flash.keep
 
     respond_to do |format|

--- a/app/controllers/journals_controller.rb
+++ b/app/controllers/journals_controller.rb
@@ -73,7 +73,7 @@ class JournalsController < ApplicationController
     session[:current_unit_id] = @journal.unit.id
 
     unless @journal.verify_journal
-      flash.now[:alert] = @journal.errors.values.join("<br/>")
+      flash.now[:alert] = @journal.errors.messages.values.join("<br/>")
     end
 
     respond_to do |format|

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -51,7 +51,7 @@ class Category < ApplicationRecord
 
     if self.is_one_percent then
       if years.include?(self.year) then
-        errors[:category] << "Tylko jedna kategoria w roku moze byc kategoria typu 1%"
+        errors.add(:category, "Tylko jedna kategoria w roku moze byc kategoria typu 1%")
       end
     end
   end
@@ -59,7 +59,7 @@ class Category < ApplicationRecord
   def cannot_have_same_grant_twice_for_same_year
     if self.grant_id.present? then
       if Category.where(year: self.year, grant_id: self.grant_id).present? then
-        errors[:category] << "dotacja może mieć tylko jedną kategorię w danym roku"
+        errors.add(:category, "dotacja może mieć tylko jedną kategorię w danym roku")
       end
     end
   end
@@ -68,16 +68,16 @@ class Category < ApplicationRecord
     if not all_items_blank
       items_to_show = 10
 
-      errors[:category] << "Istnieją wpisy dla podanej kategorii:"
+      errors.add(:category, "Istnieją wpisy dla podanej kategorii:")
 
       category_items = self.items.select{|item| not item.amount.blank?}
       category_items.first(items_to_show).each do |item|
         entry = Entry.find(item.entry.id)
 
-        errors[:category] << entry.link_to_edit
+        errors.add(:category, entry.link_to_edit)
       end
       if category_items.count > items_to_show
-        errors[:category] << "... i inne, razem #{category_items.count} wpisów."
+        errors.add(:category, "... i inne, razem #{category_items.count} wpisów.")
       end
     end
 
@@ -90,7 +90,7 @@ class Category < ApplicationRecord
 
       if not items_to_check.blank?
         items_to_check.each do |item|
-          errors[:category] << "istnieje wpis #{item.id}"
+          errors.add(:category, "istnieje wpis #{item.id}")
         end
 
         # throw(:abort)
@@ -121,11 +121,11 @@ class Category < ApplicationRecord
       end
 
       if not item_grants_errors.empty?
-        errors[:category] << "Istnieją wpisy dla podanej dotacji:"
-        errors[:category] << item_grants_errors.first(items_to_show)
+        errors.add(:category, "Istnieją wpisy dla podanej dotacji:")
+        errors.add(:category, item_grants_errors.first(items_to_show))
 
         if item_grants_errors.count > items_to_show
-          errors[:category] << "... i inne, razem #{item_grants_errors.count} wpisów."
+          errors.add(:category, "... i inne, razem #{item_grants_errors.count} wpisów.")
         end
       end
     end

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -73,7 +73,7 @@ class Entry < ApplicationRecord
     end
 
     if categories.length != categories.uniq.length
-      errors[:items] << 'Wpis nie moze miec kilku sum z tej samej kategorii'
+      errors.add(:items, 'Wpis nie moze miec kilku sum z tej samej kategorii')
     end
   end
 
@@ -81,7 +81,7 @@ class Entry < ApplicationRecord
     items.each do |item|
       if item.category.is_one_percent
         if item.amount != item.amount_one_percent
-          errors[:items] << "Niepoprawny wpis dla kategorii 1% (amount=#{item.amount} != amount_one_percent=#{item.amount_one_percent})"
+          errors.add(:items, "Niepoprawny wpis dla kategorii 1% (amount=#{item.amount} != amount_one_percent=#{item.amount_one_percent})")
           throw :abort
         end
       end
@@ -91,7 +91,7 @@ class Entry < ApplicationRecord
   def must_be_from_journals_year
     if journal && self.date
       if self.date.year!= journal.year
-        errors[:base] << "Wpis nie moze byc z innego roku: journal.year=#{journal.year} != entry.year=#{self.date.year}"
+        errors.add(:base, "Wpis nie moze byc z innego roku: journal.year=#{journal.year} != entry.year=#{self.date.year}")
         throw :abort
       end
     end
@@ -101,12 +101,12 @@ class Entry < ApplicationRecord
     if journal
       items.each do |item|
         if item.nil? || item.category.nil? || item.category.year.nil?
-          errors[:base] << "Wpis musi miec kategorie z danego roku"
+          errors.add(:base, "Wpis musi miec kategorie z danego roku")
           throw :abort
         end
 
         if item.category.year != journal.year
-          errors[:base] << "Wpis nie moze miec sumy dla kategorii z innego roku niz ksiazka: journal.year=#{journal.year} != category.year=#{item.category.year}"
+          errors.add(:base, "Wpis nie moze miec sumy dla kategorii z innego roku niz ksiazka: journal.year=#{journal.year} != category.year=#{item.category.year}")
           throw :abort
         end
       end
@@ -116,7 +116,7 @@ class Entry < ApplicationRecord
   def should_not_change_if_journal_is_closed
     if journal
       unless journal.is_not_blocked(self.date)
-        errors[:journal] << "Aby zmieniać wpisy książka musi być otwarta"
+        errors.add(:journal, "Aby zmieniać wpisy książka musi być otwarta")
         throw :abort
       end
     end
@@ -130,7 +130,7 @@ class Entry < ApplicationRecord
         is_expense = true if item.category.is_expense
         is_income = true unless item.category.is_expense
         if is_expense && is_income
-          errors[:base] << "Wpis nie może być jednocześnie wpływem i wydatkiem"
+          errors.add(:base, "Wpis nie może być jednocześnie wpływem i wydatkiem")
         end
       end
     end
@@ -139,7 +139,7 @@ class Entry < ApplicationRecord
   def linked_entry_sum_must_match
     if linked_entry != nil
       if self.sum != linked_entry.sum
-        errors[:linked_entry] << "Połączony wpis musi mieć taką samą kwotę"
+        errors.add(:linked_entry, "Połączony wpis musi mieć taką samą kwotę")
       end
     end
   end
@@ -147,7 +147,7 @@ class Entry < ApplicationRecord
   def linked_entry_must_be_opposite
     if linked_entry != nil
       if self.is_expense == linked_entry.is_expense
-        errors[:linked_entry] << "Połączony wpis musi być odwrotnego typu"
+        errors.add(:linked_entry, "Połączony wpis musi być odwrotnego typu")
       end
     end
   end

--- a/app/models/grant.rb
+++ b/app/models/grant.rb
@@ -42,14 +42,14 @@ class Grant < ApplicationRecord
     if categories.present? then
       categories_to_show = 10
 
-      errors[:base] << "Błąd usuwania - dotacja włączona w poniższych latach:"
+      errors.add(:base, "Błąd usuwania - dotacja włączona w poniższych latach:")
 
       categories.first(categories_to_show).each do |category|
-        errors[:base] << category.year
+        errors.add(:base, category.year)
       end
 
       if categories.count > categories_to_show
-        errors[:base] << "... i inne, razem #{categories.count} kategorii."
+        errors.add(:base, "... i inne, razem #{categories.count} kategorii.")
       end
 
       throw(:abort)

--- a/app/models/inventory_entry.rb
+++ b/app/models/inventory_entry.rb
@@ -43,7 +43,7 @@ class InventoryEntry < ApplicationRecord
       return true
     end
 
-    errors[:inventory_entry] << "Nie można użyć nieaktywnego źródła #{inventory_source.name}"
+    errors.add(:inventory_entry, "Nie można użyć nieaktywnego źródła #{inventory_source.name}")
     return false
   end
 
@@ -58,7 +58,7 @@ class InventoryEntry < ApplicationRecord
       return true
     end
 
-    errors[:inventory_entry] << "Źródło #{inventory_source.name} dla roku #{date.year} jest zamknięte"
+    errors.add(:inventory_entry, "Źródło #{inventory_source.name} dla roku #{date.year} jest zamknięte")
     return false
   end
 

--- a/app/models/inventory_source.rb
+++ b/app/models/inventory_source.rb
@@ -21,7 +21,7 @@ class InventorySource < ApplicationRecord
 
   def prevent_changes_for_finance_bank
     if self.id == InventorySource::FINANCE_TYPE_ID || self.id == InventorySource::BANK_TYPE_ID
-      errors[:inventory_source] << "Nie można edytować źródła #{self.name}"
+      errors.add(:inventory_source, "Nie można edytować źródła #{self.name}")
       throw(:abort)
     end
   end
@@ -29,7 +29,7 @@ class InventorySource < ApplicationRecord
   def check_for_inventory_entries
     return true if inventory_entries.count == 0
 
-    errors[:inventory_source] << "Nie można kasować źródła dla którego istnieją wpisy"
+    errors.add(:inventory_source, "Nie można kasować źródła dla którego istnieją wpisy")
     throw(:abort)
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -55,14 +55,14 @@ class Item < ApplicationRecord
   def cannot_have_amount_one_percent_greater_than_amount
     if self.amount != nil && self.amount_one_percent != nil
       if self.amount_one_percent.abs > self.amount.abs && !category.is_one_percent
-        errors[:items] << " - wartość dla 1% (#{self.amount_one_percent}) musi być mniejsza niż wartość główna (#{self.amount})"
+        errors.add(:items, " - wartość dla 1% (#{self.amount_one_percent}) musi być mniejsza niż wartość główna (#{self.amount})")
       end
     end
   end
 
   def cannot_have_amount_one_percent_if_amount_is_nil
     if self.amount == nil && self.amount_one_percent != nil && self.amount_one_percent != 0 then
-      errors[:items] << " - podano wartość dla 1% (#{self.amount_one_percent}) bez podania wartości głównej"
+      errors.add(:items, " - podano wartość dla 1% (#{self.amount_one_percent}) bez podania wartości głównej")
     end
   end
 
@@ -70,7 +70,7 @@ class Item < ApplicationRecord
     grants_amounts = self.item_grants.map(&:amount).map(&:to_i)
 
     if self.amount == nil && grants_amounts.count > 0 && grants_amounts.sum != 0 then
-      errors[:items] << " - podano wartości dla dotacji (w sumie #{grants_amounts.sum}) bez podania wartości głównej"
+      errors.add(:items, " - podano wartości dla dotacji (w sumie #{grants_amounts.sum}) bez podania wartości głównej")
     end
   end
 
@@ -78,7 +78,7 @@ class Item < ApplicationRecord
     grants_sum = self.item_grants.map(&:amount).sum(&:to_i) + self.amount_one_percent.to_i
     if grants_sum.abs > self.amount.to_i.abs
 
-      errors[:items] << "Suma z dotacji (" + grants_sum.to_s + ") musi mieścić się w wartości wpisu (" + self.amount.to_s + ")"
+      errors.add(:items, "Suma z dotacji (" + grants_sum.to_s + ") musi mieścić się w wartości wpisu (" + self.amount.to_s + ")")
     end
   end
 
@@ -96,7 +96,7 @@ class Item < ApplicationRecord
       end
 
       if error
-        errors[:items] << "Jeżeli wartość wpisu jest większa od 0 to wpisy dla dotacji też muszą być większe od 0"
+        errors.add(:items, "Jeżeli wartość wpisu jest większa od 0 to wpisy dla dotacji też muszą być większe od 0")
       end
 
     elsif self.amount < 0
@@ -107,7 +107,7 @@ class Item < ApplicationRecord
       end
 
       if error
-        errors[:items] << "Jeżeli wartość wpisu jest mniejsza od 0 to wpisy dla dotacji też muszą być mniejsze od 0"
+        errors.add(:items, "Jeżeli wartość wpisu jest mniejsza od 0 to wpisy dla dotacji też muszą być mniejsze od 0")
       end
     end
   end

--- a/app/models/journal.rb
+++ b/app/models/journal.rb
@@ -315,7 +315,7 @@ class Journal < ApplicationRecord
 
   def verify_balance_one_percent_not_less_than_zero(to_date = end_of_year)
     if self.get_balance_one_percent(to_date) < 0
-      errors[:one_percent] << I18n.t(:sum_one_percent_must_not_be_less_than_zero, :sum_one_percent => get_balance_one_percent(to_date), :scope => :journal)
+      errors.add(:one_percent, I18n.t(:sum_one_percent_must_not_be_less_than_zero, :sum_one_percent => get_balance_one_percent(to_date), :scope => :journal))
       return false
     else
       return true
@@ -327,7 +327,7 @@ class Journal < ApplicationRecord
 
     Grant.all.each do |grant|
       if self.get_balance_for_grant(grant, to_date) < 0
-        errors[:grants] << "Saldo końcowe dla dotacji " + grant.name + " (" + self.get_balance_for_grant(grant, to_date).to_s + ") nie może być mniejsze niż zero"
+        errors.add(:grants, "Saldo końcowe dla dotacji " + grant.name + " (" + self.get_balance_for_grant(grant, to_date).to_s + ") nie może być mniejsze niż zero")
         result = false
       end
     end
@@ -350,9 +350,9 @@ class Journal < ApplicationRecord
     end
 
     if total_balance < 0
-      errors[:one_percent] << "Saldo końcowe (" + total_balance.to_s + ") jest ujemne - proszę rozliczyć do zera środki z wszystkich dotacji (aktualnie " + balances_sum.to_s + ")"
+      errors.add(:one_percent, "Saldo końcowe (" + total_balance.to_s + ") jest ujemne - proszę rozliczyć do zera środki z wszystkich dotacji (aktualnie " + balances_sum.to_s + ")")
     else
-      errors[:one_percent] << "Saldo końcowe dla dotacji (" + balances_sum.to_s + ") nie może być większe niż saldo książki (" + total_balance.to_s + ")"
+      errors.add(:one_percent, "Saldo końcowe dla dotacji (" + balances_sum.to_s + ") nie może być większe niż saldo książki (" + total_balance.to_s + ")")
     end
     return false
   end
@@ -362,7 +362,7 @@ class Journal < ApplicationRecord
     self.entries.each do |entry|
       if !entry.verify_entry
         result = false
-        errors[:entry] << entry.errors.values
+        errors.add(:entry, entry.errors).values
       end
     end
     return result
@@ -374,7 +374,7 @@ class Journal < ApplicationRecord
     inventoryVerifier = InventoryEntryVerifier.new(self.unit)
     years_to_verify = [self.year]
     unless inventoryVerifier.verify(years_to_verify)
-      errors[:inventory] << '<br/>' + inventoryVerifier.errors.values.join("<br/><br/>")
+      inventoryVerifier.errors.add.values.join("<br/><br/>")
       result = false
     end
 
@@ -472,7 +472,7 @@ class Journal < ApplicationRecord
 
   private
   def add_error_for_duplicated_type
-    errors[:journal_type] << I18n.t(:journal_for_this_year_and_type_already_exists, :year => self.year, :type => self.journal_type.name, :scope => :journal)
+    errors.add(:journal_type, I18n.t(:journal_for_this_year_and_type_already_exists, :year => self.year, :type => self.journal_type.name, :scope => :journal))
   end
 
   def Journal.end_of_year(year)
@@ -485,7 +485,7 @@ class Journal < ApplicationRecord
 
   def verify_block_date(date)
     if date.year != self.year or date.blank? or not date.is_a?(Date)
-      errors[:blocked_to] << "Błędna data zamknięcia książki"
+      errors.add(:blocked_to, "Błędna data zamknięcia książki")
       return false
     end
 

--- a/app/models/unit.rb
+++ b/app/models/unit.rb
@@ -90,7 +90,8 @@ class Unit < ApplicationRecord
   def unit_has_open_journals
     open_journals = self.journals.select { |journal| journal.is_not_blocked()}
     if open_journals.count > 0
-      errors[:journal] << "jednostka posiada niezamknięte książki w latach: " + open_journals.map(&:year).uniq().join(', ')
+      msg = "jednostka posiada niezamknięte książki w latach: " + open_journals.map(&:year).uniq().join(', ')
+      errors.add(:journal, msg)
       return false
     end
 


### PR DESCRIPTION
Refaktor pod przyszłą aktualizację do Rails 7.0 - poprawia następujące ostrzeżenia występujące w `rake test`:

> DEPRECATION WARNING: Calling `<<` to an ActiveModel::Errors message array in order to add an error is deprecated. Please call `ActiveModel::Errors#add` instead.

> DEPRECATION WARNING: ActiveModel::Errors#values is deprecated and will be removed in Rails 7.0.